### PR TITLE
Added Node Version Manager Installation to Setup

### DIFF
--- a/docs/slides/content/01/01.md
+++ b/docs/slides/content/01/01.md
@@ -309,7 +309,10 @@ Programmiersprache: TypeScript (statt JavaScript)
 - [Microsoft VS Code](https://code.visualstudio.com/Download) installieren
   - Tipp: [Telemetrie abschalten](https://code.visualstudio.com/docs/getstarted/telemetry#_disable-telemetry-reporting)
   - Alternative [VSCodium](https://github.com/VSCodium/vscodium/)
-- [Node.js](https://nodejs.org/en/) Version "20 LTS" installieren (Profis ggf. mit `fnm`)
+- [Node.js](https://nodejs.org/en/) Version "22 LTS" installieren (Profis ggf. mit `fnm`)
+- [Node Version Manager NVM - Windows](https://github.com/coreybutler/nvm-windows) node.js Versionsmanagement für einfaches Versionhandling. 
+- [Node Version Manager NVM - Mac](https://sukiphan.medium.com/how-to-install-nvm-node-version-manager-on-macos-d9fe432cc7db)
+  - [NVM Usage](https://github.com/coreybutler/nvm-windows?tab=readme-ov-file#usage)
 - [Git](https://git-scm.com/download) installieren
   - Win: Standard durchklicken
   - Mac: Empfehlung homebrew 🍺 (Via pkg oder sh)


### PR DESCRIPTION
As proposed in #6 I added tutorials and download links for node version manager.
Which I think could be an alternative or even substitution instead of installing node.js directly. 

In addition I updated the LTS Version of node.js

Is the target branch correct or would be 25/hs be better? 